### PR TITLE
Fix typo in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ function App() {
 `from` prop allows you to create a microstate by providing an initial value for the microstate without providing a Type. Microstates will figure out the transitions and state from the value itself.
 
 ```js
-import Microstates from "@microstates/react";
+import State from "@microstates/react";
 
 function App() {
   return (


### PR DESCRIPTION
The `import` statement in the example was importing `Microstates`, but it should have been importing `State`.